### PR TITLE
Fix `defaultRichTextElements` not resolving

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ interface IntlConfig {
   messages: Record<MessageIds, string> | Record<MessageIds, MessageFormatElement[]>;
   defaultLocale?: string;
   defaultFormats?: CustomFormats;
-  defaultRichTextElements?: Record<string, FormatXMLElementFn<T>>;
+  defaultRichTextElements?: Record<string, FormatXMLElementFn<JSXElement>>;
   onError(err: MissingTranslationError | MessageFormatError | MissingDataError | InvalidConfigError | UnsupportedFormatterError | FormatError)?: void;
   onWarn(warning: string)?: void;
 }

--- a/dev/application.tsx
+++ b/dev/application.tsx
@@ -1,6 +1,6 @@
 import { render } from "solid-js/web";
 import "./styles.css";
 
-import Root from "./Root";
+import Root from "./root";
 
 render(() => <Root />, document.getElementById("root")!);

--- a/dev/assets/translations/en.json
+++ b/dev/assets/translations/en.json
@@ -1,5 +1,6 @@
 {
   "app.greeting": "Hello, {name}!",
   "app.cta": "Change the language to see solid-intl in action!",
-  "app.link": "<a>Learn Solid</a> "
+  "app.link": "<a>Learn Solid</a> ",
+  "app.bold": "We <b>love</a> Solid!"
 }

--- a/dev/home/home.tsx
+++ b/dev/home/home.tsx
@@ -1,4 +1,4 @@
-import { For } from "solid-js";
+import { For, JSXElement } from "solid-js";
 import type { Component } from "solid-js";
 
 import { useIntl, defineMessages } from "../../src";
@@ -18,6 +18,10 @@ const messages = defineMessages({
   link: {
     id: "app.link",
     defaultMessage: "<a>Learn Solid</a> ",
+  },
+  bold: {
+    id: "app.bold",
+    defaultMessage: "We <b>love</b> Solid!",
   },
 });
 
@@ -40,7 +44,8 @@ const Home: Component<HomeElement> = (props) => {
         <img src={logo} class={styles.logo} alt="logo" />
         <p>{intl.formatMessage(messages.greeting, { name: "gentleman" })}</p>
         <p>{intl.formatMessage(messages.cta)}</p>
-        {intl.formatMessage(messages.link, {
+        <p>{intl.formatMessage(messages.bold)}</p>
+        {intl.formatMessage<JSXElement>(messages.link, {
           a: (str) => (
             <a
               class={styles.link}

--- a/dev/home/home.tsx
+++ b/dev/home/home.tsx
@@ -1,5 +1,5 @@
-import { For, JSXElement } from "solid-js";
-import type { Component } from "solid-js";
+import { For } from "solid-js";
+import type { Component, JSXElement } from "solid-js";
 
 import { useIntl, defineMessages } from "../../src";
 import logo from "../logo.svg";

--- a/dev/root/root.tsx
+++ b/dev/root/root.tsx
@@ -29,7 +29,12 @@ const Root: Component = () => {
   };
 
   return (
-    <IntlProvider locale={lang()} messages={translations()}>
+    <IntlProvider
+      locale={lang()}
+      messages={translations()}
+      defaultRichTextElements={{
+        b: (chunks) => <b>{chunks}</b>
+      }}>
       <Home onLangChange={handleLangChange} />
     </IntlProvider>
   );

--- a/src/process-config.ts
+++ b/src/process-config.ts
@@ -12,6 +12,7 @@ function processConfig<T extends IntlConfig = IntlConfig>(config: T): Readonly<I
     messages: config.messages,
     defaultLocale: config.defaultLocale,
     defaultFormats: config.defaultFormats,
+    defaultRichTextElements: config.defaultRichTextElements,
     onError: config.onError,
     onWarn: config.onWarn,
   });

--- a/src/provider.tsx
+++ b/src/provider.tsx
@@ -1,12 +1,11 @@
 import { createComputed, createContext } from "solid-js";
 import { createStore, createMutable } from "solid-js/store";
 import { IntlCache, createIntl, createIntlCache } from "@formatjs/intl";
-import type { IntlShape } from "@formatjs/intl";
 import type { FlowComponent } from "solid-js";
 
 import processConfig from "./process-config";
 import is from "./utils/is";
-import type { IntlConfig } from "./types";
+import type { IntlConfig, IntlShape } from "./types";
 
 const IntlContext = createContext<IntlShape>();
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,13 @@
-import type { IntlShape, ResolvedIntlConfig, MessageDescriptor } from "@formatjs/intl";
+import type {
+  IntlShape as CoreIntlShape,
+  ResolvedIntlConfig as CoreResolvedIntlConfig,
+  MessageDescriptor,
+} from "@formatjs/intl";
+import type { JSXElement } from "solid-js";
+
+type ResolvedIntlConfig = CoreResolvedIntlConfig<JSXElement>;
+
+type IntlShape = CoreIntlShape<JSXElement>;
 
 type IntlConfig = Partial<Omit<ResolvedIntlConfig, "locale" | "messages">> &
   Required<Pick<ResolvedIntlConfig, "locale" | "messages">>;

--- a/src/use-intl.test.tsx
+++ b/src/use-intl.test.tsx
@@ -89,5 +89,19 @@ describe("useIntl()", () => {
 
       expect(screen.getByText(es["app.greeting"])).toBeInTheDocument();
     });
+
+    it("should format messages with defaultRichTextElements specified", () => {
+      render(() => (
+        <IntlProvider
+          locale="en"
+          messages={{ "app.greeting": "My <bar>message</bar> formatted." }}
+          defaultRichTextElements={{ bar: (chunks) => <span data-testid="bar">{chunks}</span> }}
+        >
+          <Foo />
+        </IntlProvider>
+      ));
+
+      expect(screen.getAllByTestId("bar")).toHaveLength(1);
+    });
   });
 });


### PR DESCRIPTION
Fixes #1 

Adjusts types to use `JSXElement` like how `react-intl` uses `ReactNode` ([see here](https://github.com/formatjs/formatjs/blob/649a386f4437cdb0edb0f7d894d56c7a629e9f37/packages/react-intl/src/types.ts)) and adds `defaultRichTextElements` to `process-config` function so that it's included in the Provider.